### PR TITLE
ci(workflows): run only using sccache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ env:
   # prevents out of disk space error
   CARGO_INCREMENTAL: 0
   CARGO_PROFILE_DEV_DEBUG: 0
-  # enable caching for faster compilation
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 
 jobs:
   build:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Removed the "Setup Rust cache" step from the continuous integration workflow, streamlining the build process.
	- Eliminated the "Run sccache-cache" step, further optimizing workflow efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->