### PR TITLE
ci(workflows): run nightly only on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       #     file: ./coverage.lcov
 
   nightly:
-    if: github.event.schedule == '0 0 * * *'
+    if: github.event.schedule == '0 0 * * *' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Actions workflow to ensure the nightly job runs only on the master branch at midnight UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->