### PR TITLE
fix: use correct values in config and log correct nos. of maps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,6 @@ jobs:
       - name: Upload Coverage Report 📤
         uses: coverallsapp/github-action@v2.3.4
         with:
-          parallel: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: ./coverage.lcov
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,18 @@ jobs:
       - name: Combine coverage
         run: cargo llvm-cov report --lcov --output-path coverage.lcov
 
-      # TODO: uncomment me once we are a public repo
       - name: Upload Coverage Report 📤
         uses: coverallsapp/github-action@v2.3.4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: ./coverage.lcov
+
+      # TODO: remove me when coveralls does not pause for a long while even
+      # after workflow steps are finished
+      - name: Force mark Coveralls build as finished
+        uses: coverallsapp/github-action@v2.3.4
+        with:
+          parallel-finished: true
 
   nightly:
     if: github.event.schedule == '0 0 * * *' && github.ref == 'refs/heads/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Upload Coverage Report 📤
         uses: coverallsapp/github-action@v2.3.4
         with:
+          parallel: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: ./coverage.lcov
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: ./coverage.lcov
+          parallel: true
+          flag-name: coverage-remove-me-when-coveralls-does-not-pause
 
       # TODO: remove me when coveralls does not pause for a long while even
       # after workflow steps are finished

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -57,7 +57,7 @@ pub struct Model {
 impl Default for Model {
     fn default() -> Self {
         Self {
-            cycle: Duration::from_secs(2),
+            cycle: Duration::from_secs(20),
             usecorrelation: true,
             minsize: 2_000_000,
             memtotal: -10,

--- a/crates/config/src/system.rs
+++ b/crates/config/src/system.rs
@@ -87,17 +87,15 @@ impl Default for System {
             autosave: Duration::from_secs(3600),
             // TODO: can use mapexclude and exeexclude
             mapprefix: vec![
-                PathBuf::from("/opt"),
-                PathBuf::from("!/usr/sbin/"),
-                PathBuf::from("!/usr/local/sbin/"),
-                PathBuf::from("!/usr/"),
+                PathBuf::from("/usr/"),
+                PathBuf::from("/lib/"),
+                PathBuf::from("/var/cache/"),
                 PathBuf::from("!/"),
             ],
             exeprefix: vec![
-                "/opt".into(),
                 "!/usr/sbin/".into(),
                 "!/usr/local/sbin/".into(),
-                "!/usr/".into(),
+                "/usr/".into(),
                 "!/".into(),
             ],
             processes: 30,

--- a/crates/kernel/src/state/inner.rs
+++ b/crates/kernel/src/state/inner.rs
@@ -13,6 +13,7 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     mem,
     path::{Path, PathBuf},
+    sync::{atomic::AtomicU64, Arc},
 };
 use sysinfo::{ProcessRefreshKind, RefreshKind, System, UpdateKind};
 use tracing::{debug, enabled, error, trace, warn, Level};
@@ -376,7 +377,7 @@ impl StateInner {
         // XXX: we only readahead a subset of all maps. Maybe find a better way
         // to select maps to readahead without additional vec allocation.
         let mut maps_to_readahead = vec![];
-        let mut num_maps_readahead = 0;
+        let mut num_maps_to_readahead = 0;
 
         let mut maps_iter = self.maps.iter().sorted_by(|a, b| {
             a.lnprob()
@@ -384,8 +385,8 @@ impl StateInner {
                 .unwrap_or(Ordering::Equal)
         });
         // XXX: clean up the loop
-        while num_maps_readahead < maps_iter.len() {
-            let Some(map) = maps_iter.nth(num_maps_readahead) else {
+        while num_maps_to_readahead < maps_iter.len() {
+            let Some(map) = maps_iter.nth(num_maps_to_readahead) else {
                 error!("Map not found. Please report a bug!");
                 break;
             };
@@ -406,12 +407,12 @@ impl StateInner {
                 );
             }
 
-            num_maps_readahead += 1;
+            num_maps_to_readahead += 1;
             maps_to_readahead.push(map);
         }
 
-        if num_maps_readahead > 0 {
-            self.preload_readahead(&mut maps_to_readahead);
+        if num_maps_to_readahead > 0 {
+            let num_maps_readahead = self.preload_readahead(&mut maps_to_readahead);
             let num_maps = self.maps.len();
             debug!(
                 num_maps_readahead,
@@ -425,7 +426,7 @@ impl StateInner {
     }
 
     #[tracing::instrument(skip_all)]
-    fn preload_readahead(&self, maps: &mut [&Map]) {
+    fn preload_readahead(&self, maps: &mut [&Map]) -> u64 {
         // sort files
         if let Some(sort_strategy) = self.config.system.sortstrategy {
             trace!("Sorting {} maps by {:?}.", maps.len(), sort_strategy);
@@ -458,14 +459,19 @@ impl StateInner {
             }
         }
 
+        let num_readahead = Arc::new(AtomicU64::new(0));
         maps.par_iter().for_each(|map| {
             // TODO: if (path && offset <= files[i]->offset ...) {}
             if let Err(error) = readahead(map.path(), map.offset() as i64, map.length() as i64) {
                 warn!(path=?map.path(), %error, "Failed to readahead");
             } else {
+                num_readahead
+                    .clone()
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 trace!(?map, "Readahead done.");
             }
         });
+        num_readahead.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     #[tracing::instrument(skip_all)]


### PR DESCRIPTION
- **fix(config): use values as originally used by preload**
- **refactor(kernel/state): correctly count the number of maps readahead**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased the default cycle duration for data gathering and predictions from 2 seconds to 20 seconds.
	- Updated default path prefixes for the preload system, potentially altering file acceptance based on their paths.
	- Enhanced tracking of readahead operations with atomic counters for improved concurrency handling.

- **Bug Fixes**
	- Improved clarity and functionality in the readahead methods, ensuring accurate reporting of processed maps.

- **Documentation**
	- Updated comments and logging statements to reflect changes in variable names and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->