### PR TITLE
feat: upgrade deps and move to rust 2024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,6 @@ jobs:
         with:
           components: clippy
 
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.7
-
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
 
@@ -83,9 +80,6 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.7
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ env:
   # prevents out of disk space error
   CARGO_INCREMENTAL: 0
   CARGO_PROFILE_DEV_DEBUG: 0
-  # enable caching for faster compilation
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 dependencies = [
  "backtrace",
 ]
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2204,18 +2204,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,11 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-thiserror = "2.0.11"
+thiserror = "2.0.12"
 tracing = "0.1.41"
 proptest = "1.6.0"
 flume = "0.11.1"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,8 +13,8 @@ thiserror.workspace = true
 tracing.workspace = true
 flume.workspace = true
 tokio.workspace = true
-anyhow = { version = "1.0.95", features = ["backtrace"] }
-clap = { version = "4.5.26", features = ["wrap_help"] }
+anyhow = { version = "1.0.97", features = ["backtrace"] }
+clap = { version = "4.5.31", features = ["wrap_help"] }
 clap-verbosity-flag = "3.0.2"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 glob = "0.3.2"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,11 +4,11 @@ use flume::bounded;
 use kernel::State;
 use preload_rs::{
     cli::Cli,
-    signals::{wait_for_signal, SignalEvent},
+    signals::{SignalEvent, wait_for_signal},
 };
 use tokio::time;
 use tracing::{debug, error, trace};
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/crates/cli/src/signals.rs
+++ b/crates/cli/src/signals.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use flume::Sender;
-use tokio::signal::unix::{signal, SignalKind};
+use tokio::signal::unix::{SignalKind, signal};
 use tracing::debug;
 
 /// Indefinitely listens to signals and sends signal events to the provided channel.

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -6,13 +6,13 @@ license.workspace = true
 
 [dependencies]
 figment = { version = "0.10.19", features = ["toml"] }
-serde = { version = "1.0.217", features = ["derive"] }
+serde = { version = "1.0.218", features = ["derive"] }
 serde_with = "3.12.0"
 thiserror.workspace = true
-toml_edit = { version = "0.22.22", features = ["serde"] }
+toml_edit = { version = "0.22.24", features = ["serde"] }
 
 [lints]
 workspace = true
 
 [dev-dependencies]
-tempfile = "3.15.0"
+tempfile = "3.17.1"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -5,8 +5,8 @@ mod system;
 
 pub use error::Error;
 use figment::{
-    providers::{Format, Serialized, Toml},
     Figment,
+    providers::{Format, Serialized, Toml},
 };
 pub use model::Model;
 use serde::{Deserialize, Serialize};

--- a/crates/kernel/Cargo.toml
+++ b/crates/kernel/Cargo.toml
@@ -5,14 +5,14 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-async-trait = "0.1.85"
+async-trait = "0.1.87"
 bincode = "1.3.3"
-bitflags = "2.8.0"
+bitflags = "2.9.0"
 config = { version = "0.1.0", path = "../config" }
 educe = { version = "0.6.0", default-features = false, features = ["Debug", "Eq", "Hash", "Ord", "PartialEq", "PartialOrd"] }
 humansize = "2.1.3"
 itertools = "0.14.0"
-libc = "0.2.169"
+libc = "0.2.170"
 nix = { version = "0.29.0", features = ["fs"] }
 parking_lot = "0.12.3"
 procfs = "0.17.0"
@@ -27,7 +27,7 @@ tracing.workspace = true
 futures = { version = "0.3.31", default-features = false }
 pretty_assertions = "1.4.1"
 proptest.workspace = true
-tempfile = "3.15.0"
+tempfile = "3.17.1"
 tokio = { workspace = true, features = ["macros", "test-util"] }
 tokio-test = "0.4.4"
 

--- a/crates/kernel/src/database.rs
+++ b/crates/kernel/src/database.rs
@@ -1,7 +1,7 @@
 use crate::Error;
 use sqlx::{
-    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
     SqlitePool,
+    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous},
 };
 use std::{path::Path, str::FromStr};
 

--- a/crates/kernel/src/exe/database.rs
+++ b/crates/kernel/src/exe/database.rs
@@ -1,5 +1,5 @@
 use super::Exe;
-use crate::{database::DatabaseWriteExt, Error};
+use crate::{Error, database::DatabaseWriteExt};
 use sqlx::SqlitePool;
 use std::{
     collections::HashMap,

--- a/crates/kernel/src/exe/mod.rs
+++ b/crates/kernel/src/exe/mod.rs
@@ -3,7 +3,7 @@
 pub(crate) mod database;
 mod inner;
 
-use crate::{extract_exe, Error, ExeMap, Markov};
+use crate::{Error, ExeMap, Markov, extract_exe};
 use inner::ExeInner;
 use parking_lot::Mutex;
 use std::{

--- a/crates/kernel/src/exemap/database.rs
+++ b/crates/kernel/src/exemap/database.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::mutable_key_type)]
 
 use super::ExeMap;
-use crate::{database::DatabaseWriteExt, Error, Exe, Map};
+use crate::{Error, Exe, Map, database::DatabaseWriteExt};
 use sqlx::SqlitePool;
 use std::{
     collections::{HashMap, HashSet},

--- a/crates/kernel/src/lib.rs
+++ b/crates/kernel/src/lib.rs
@@ -10,9 +10,9 @@ pub mod utils;
 
 pub use database::MIGRATOR;
 pub use error::Error;
-pub use exe::{database::ExeDatabaseReadExt, Exe};
-pub use exemap::{database::ExeMapDatabaseReadExt, ExeMap};
-pub use map::{database::MapDatabaseReadExt, Map, RuntimeStats};
-pub use markov::{database::MarkovDatabaseReadExt, Markov, MarkovState};
+pub use exe::{Exe, database::ExeDatabaseReadExt};
+pub use exemap::{ExeMap, database::ExeMapDatabaseReadExt};
+pub use map::{Map, RuntimeStats, database::MapDatabaseReadExt};
+pub use markov::{Markov, MarkovState, database::MarkovDatabaseReadExt};
 pub use memstat::MemStat;
-pub use state::{database::StateDatabaseReadExt, State};
+pub use state::{State, database::StateDatabaseReadExt};

--- a/crates/kernel/src/map/database.rs
+++ b/crates/kernel/src/map/database.rs
@@ -1,5 +1,5 @@
 use super::Map;
-use crate::{database::DatabaseWriteExt, Error};
+use crate::{Error, database::DatabaseWriteExt};
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 

--- a/crates/kernel/src/markov/database.rs
+++ b/crates/kernel/src/markov/database.rs
@@ -1,5 +1,5 @@
 use super::Markov;
-use crate::{database::DatabaseWriteExt, extract_exe, Error, Exe};
+use crate::{Error, Exe, database::DatabaseWriteExt, extract_exe};
 use bincode::serialize;
 use sqlx::SqlitePool;
 use std::{collections::HashMap, path::PathBuf};

--- a/crates/kernel/src/markov/inner.rs
+++ b/crates/kernel/src/markov/inner.rs
@@ -1,5 +1,5 @@
 use super::MarkovState;
-use crate::{exe::ExeForMarkov, extract_exe, Error};
+use crate::{Error, exe::ExeForMarkov, extract_exe};
 
 #[derive(Debug, Clone)]
 pub struct MarkovInner {
@@ -210,8 +210,8 @@ const fn get_markov_state(is_exe_a_running: bool, is_exe_b_running: bool) -> Mar
 mod macros {
     #[macro_export]
     macro_rules! extract_exe {
-        ($exe:expr) => {{
+        ($exe:expr) => {
             $exe.0.upgrade().ok_or(Error::ExeMarkovDeallocated)?.lock()
-        }};
+        };
     }
 }

--- a/crates/kernel/src/markov/mod.rs
+++ b/crates/kernel/src/markov/mod.rs
@@ -2,7 +2,7 @@ pub(crate) mod database;
 mod inner;
 mod markov_state;
 
-use crate::{exe::ExeForMarkov, extract_exe, Error};
+use crate::{Error, exe::ExeForMarkov, extract_exe};
 use inner::MarkovInner;
 pub use markov_state::MarkovState;
 use parking_lot::Mutex;

--- a/crates/kernel/src/memstat.rs
+++ b/crates/kernel/src/memstat.rs
@@ -1,5 +1,5 @@
 use crate::Error;
-use procfs::{page_size, vmstat, Current, Meminfo};
+use procfs::{Current, Meminfo, page_size, vmstat};
 
 #[derive(Debug, Clone, Copy)]
 pub struct MemStat {

--- a/crates/kernel/src/state/database.rs
+++ b/crates/kernel/src/state/database.rs
@@ -2,15 +2,15 @@
 
 use super::inner::StateInner;
 use crate::{
-    database::DatabaseWriteExt,
-    exe::database::{read_bad_exes, write_bad_exe},
     Error, Exe, ExeDatabaseReadExt, ExeMap, ExeMapDatabaseReadExt, Map, MapDatabaseReadExt, Markov,
     MarkovDatabaseReadExt,
+    database::DatabaseWriteExt,
+    exe::database::{read_bad_exes, write_bad_exe},
 };
 use sqlx::SqlitePool;
 use std::sync::{
-    atomic::{AtomicU64, Ordering},
     Arc,
+    atomic::{AtomicU64, Ordering},
 };
 use tracing::{debug, info, trace};
 

--- a/crates/kernel/src/state/inner.rs
+++ b/crates/kernel/src/state/inner.rs
@@ -1,9 +1,9 @@
 use crate::{
-    utils::{accept_file, kb, readahead, sanitize_file},
     Error, Exe, ExeMap, Map, MemStat,
+    utils::{accept_file, kb, readahead, sanitize_file},
 };
 use config::{Config, Model, SortStrategy};
-use humansize::{format_size_i, DECIMAL};
+use humansize::{DECIMAL, format_size_i};
 use itertools::Itertools;
 use libc::pid_t;
 use procfs::process::MMapPath;
@@ -13,10 +13,10 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     mem,
     path::{Path, PathBuf},
-    sync::{atomic::AtomicU64, Arc},
+    sync::{Arc, atomic::AtomicU64},
 };
 use sysinfo::{ProcessRefreshKind, RefreshKind, System, UpdateKind};
-use tracing::{debug, enabled, error, trace, warn, Level};
+use tracing::{Level, debug, enabled, error, trace, warn};
 
 #[derive(Debug, Default)]
 pub(crate) struct StateInner {

--- a/crates/kernel/src/state/mod.rs
+++ b/crates/kernel/src/state/mod.rs
@@ -2,8 +2,8 @@ pub(crate) mod database;
 mod inner;
 
 use crate::{
-    database::{create_database_pool, DatabaseWriteExt},
-    Error, StateDatabaseReadExt, MIGRATOR,
+    Error, MIGRATOR, StateDatabaseReadExt,
+    database::{DatabaseWriteExt, create_database_pool},
 };
 use config::Config;
 use inner::StateInner;

--- a/crates/kernel/src/utils.rs
+++ b/crates/kernel/src/utils.rs
@@ -105,7 +105,7 @@ pub fn sanitize_file(path: &Path) -> Option<&Path> {
     // get rid of prelink and accept it
     let new_path = path.to_str().and_then(|x| x.split(".#prelink#.").next())?;
     // (non-prelinked) deleted files
-    if path.to_str().map_or(false, |s| s.contains("(deleted)")) {
+    if path.to_str().is_some_and(|s| s.contains("(deleted)")) {
         return None;
     }
     Some(Path::new(new_path))
@@ -158,7 +158,7 @@ pub fn readahead(path: impl AsRef<Path>, offset: i64, length: i64) -> Result<(),
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
-    use std::fs::{metadata, File};
+    use std::fs::{File, metadata};
     use std::io::Write;
     use std::path::PathBuf;
 


### PR DESCRIPTION
- **build(deps): upgrade deps and move to rust 2024**
- **ci: no need of using sccache**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Modernized the project configuration by updating the Rust edition and various dependency versions.
  - Streamlined the CI build process by removing outdated caching steps.

- **Style / Refactor**
  - Reorganized internal module import and export order to improve code clarity and maintainability.
  - Adjusted import statement orders across multiple files for better organization.

These internal improvements help ensure continued stability and efficiency while keeping user-facing functionality consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->