### PR TITLE
Fix comment typo

### DIFF
--- a/crates/config/src/system.rs
+++ b/crates/config/src/system.rs
@@ -61,7 +61,7 @@ pub struct System {
     pub mapprefix: Vec<PathBuf>,
 
     /// The syntax for this is exactly the same as for mapprefix. The only
-    /// difference is that this is used to accept or reject binary exectuable
+    /// difference is that this is used to accept or reject binary executable
     /// files instead of maps.
     pub exeprefix: Vec<String>,
 


### PR DESCRIPTION
## Summary
- fix a typo in `System` configuration docs

## Testing
- `cargo check` *(fails: error returned from database unable to open database file)*


------
https://chatgpt.com/codex/tasks/task_e_683f41940aec8329815bfa447bedf980