### PR TITLE
Add merging and bounded parallel readahead

### DIFF
--- a/crates/kernel/src/map/mod.rs
+++ b/crates/kernel/src/map/mod.rs
@@ -65,8 +65,8 @@ impl Map {
         self.inner.runtime.lock().lnprob = lnprob;
     }
 
-    pub fn set_block(&self) -> Result<(), Error> {
-        self.inner.set_block()
+    pub fn set_block(&self, use_inode: bool) -> Result<(), Error> {
+        self.inner.set_block(use_inode)
     }
 }
 


### PR DESCRIPTION
## Summary
- implement file block discovery with FIBMAP when sorting by block
- support selecting inode or block sorting in `set_block`
- merge adjacent maps before readahead and limit parallelism
- add unit test covering merging logic

## Testing
- `cargo check`
- `cargo test`
- `pre-commit run --files crates/kernel/src/map/inner.rs crates/kernel/src/map/mod.rs crates/kernel/src/state/inner.rs` *(fails: 'cargo-fmt' and 'cargo-clippy' not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f4b55f4d08329807819b7625fc440