### PR TITLE
fix: sort panics from NaN scores and missing sort keys

### DIFF
--- a/crates/cli/tests/signals.rs
+++ b/crates/cli/tests/signals.rs
@@ -78,7 +78,7 @@ save_on_shutdown = true\n"
     fn wait_for_output(mut child: Child) -> io::Result<Output> {
         let start = Instant::now();
         loop {
-            if let Some(_) = child.try_wait()? {
+            if child.try_wait()?.is_some() {
                 break;
             }
             if start.elapsed() > Duration::from_secs(10) {

--- a/crates/orchestrator/src/prediction/predictor.rs
+++ b/crates/orchestrator/src/prediction/predictor.rs
@@ -45,7 +45,11 @@ impl MarkovPredictor {
         let numerator = (t as f32 * ab_time as f32) - (a_time as f32 * b_time as f32);
         let denom =
             (a_time as f32 * b_time as f32 * (t - a_time) as f32 * (t - b_time) as f32).sqrt();
-        if denom == 0.0 { 0.0 } else { numerator / denom }
+        if denom == 0.0 {
+            return 0.0;
+        }
+        let corr = numerator / denom;
+        if corr.is_finite() { corr } else { 0.0 }
     }
 
     fn p_needed(
@@ -56,7 +60,9 @@ impl MarkovPredictor {
     ) -> f32 {
         let state_ix = state.index();
         let tt = edge.time_to_leave[state_ix];
-        if tt <= 0.0 {
+        // `tt <= 0.0` alone would let NaN (e.g. from corrupt persisted state)
+        // slip through and poison every downstream score.
+        if !tt.is_finite() || tt <= 0.0 {
             return 0.0;
         }
         let p_state_change = 1.0 - (-cycle / tt).exp();
@@ -64,7 +70,8 @@ impl MarkovPredictor {
         let both_ix = MarkovState::Both.index();
         let p_runs_next =
             edge.transition_prob[state_ix][target_ix] + edge.transition_prob[state_ix][both_ix];
-        (p_state_change * p_runs_next).clamp(0.0, 1.0)
+        let p = (p_state_change * p_runs_next).clamp(0.0, 1.0);
+        if p.is_nan() { 0.0 } else { p }
     }
 }
 
@@ -220,11 +227,13 @@ mod tests {
     }
 
     fn edge_strategy() -> impl Strategy<Value = (u8, u8, [f32; 4], [[f32; 4]; 4], u64)> {
+        // Full f32 range (including NaN and infinities) models corrupt or
+        // legacy persisted state; scores must stay finite regardless.
         (
             0u8..16,
             0u8..16,
-            prop::array::uniform4(0f32..100f32),
-            prop::array::uniform4(prop::array::uniform4(0f32..1f32)),
+            prop::array::uniform4(prop::num::f32::ANY),
+            prop::array::uniform4(prop::array::uniform4(prop::num::f32::ANY)),
             0u64..10_000,
         )
     }

--- a/crates/orchestrator/src/prefetch/planner.rs
+++ b/crates/orchestrator/src/prefetch/planner.rs
@@ -5,7 +5,6 @@ use crate::prediction::Prediction;
 use crate::prefetch::PrefetchPlan;
 use crate::stores::Stores;
 use config::{Config, SortStrategy};
-use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fs;
 use std::os::linux::fs::MetadataExt;
@@ -83,7 +82,7 @@ impl PrefetchPlanner for GreedyPrefetchPlanner {
             .iter()
             .map(|(id, score)| (*id, *score))
             .collect();
-        items.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
+        items.sort_by(|a, b| b.1.total_cmp(&a.1));
 
         let mut budget_kb = self.available_kb(memstat);
         let mut selected = Vec::new();
@@ -205,21 +204,16 @@ enum SortKey {
 }
 
 fn sort_by_score_and_key<K: Ord>(items: &mut [SelectedWithKey<K>]) {
+    // The comparator must be a strict total order: mixing key-based and
+    // index-based tie-breaks per pair is not transitive and makes the sort
+    // panic when some maps lack a sort key (e.g. their file vanished).
+    // Keyless maps (None) group before keyed ones within a score tier.
     items.sort_by(|a, b| {
-        let score_cmp = b
-            .item
+        b.item
             .score
-            .partial_cmp(&a.item.score)
-            .unwrap_or(Ordering::Equal);
-        if score_cmp != Ordering::Equal {
-            return score_cmp;
-        }
-        match (&a.key, &b.key) {
-            (Some(a_key), Some(b_key)) => a_key
-                .cmp(b_key)
-                .then_with(|| a.item.index.cmp(&b.item.index)),
-            _ => a.item.index.cmp(&b.item.index),
-        }
+            .total_cmp(&a.item.score)
+            .then_with(|| a.key.cmp(&b.key))
+            .then_with(|| a.item.index.cmp(&b.item.index))
     });
 }
 

--- a/crates/orchestrator/tests/predictor.rs
+++ b/crates/orchestrator/tests/predictor.rs
@@ -44,3 +44,44 @@ fn predictor_scores_non_running_exe_from_edge() {
     let map_score = prediction.map_scores.get(&map_id).copied().unwrap();
     assert!((map_score - a_score).abs() < 1e-6);
 }
+
+/// Corrupt persisted Markov data (NaN time_to_leave/transition_prob) must not
+/// leak NaN into the scores, which would later panic the planner's sort.
+#[test]
+fn predictor_scores_stay_finite_with_nan_edge_data() {
+    let mut config = Config::default();
+    config.model.use_correlation = true;
+    config.model.cycle = Duration::from_secs(1);
+
+    let mut stores = Stores::default();
+    let exe_a = stores.ensure_exe(ExeKey::new(PathBuf::from("/usr/bin/a")));
+    let exe_b = stores.ensure_exe(ExeKey::new(PathBuf::from("/usr/bin/b")));
+
+    stores.model_time = 10;
+    stores.exes.get_mut(exe_a).unwrap().running = false;
+    stores.exes.get_mut(exe_b).unwrap().running = false;
+    stores.exes.get_mut(exe_a).unwrap().total_running_time = 5;
+    stores.exes.get_mut(exe_b).unwrap().total_running_time = 5;
+
+    let now = stores.model_time;
+    stores.ensure_markov_edge(exe_a, exe_b, now, MarkovState::Neither);
+    let edge_key = EdgeKey::new(exe_a, exe_b);
+    let edge = stores.markov.get_mut(edge_key).unwrap();
+    edge.time_to_leave = [f32::NAN; 4];
+    edge.transition_prob = [[f32::NAN; 4]; 4];
+
+    let map_id = stores.ensure_map(MapSegment::new("/usr/lib/libfoo.so", 0, 2048, now));
+    stores.attach_map(exe_a, map_id);
+
+    let predictor = MarkovPredictor::new(&config);
+    let prediction = predictor.predict(&stores);
+
+    for score in prediction.exe_scores.values() {
+        assert!(score.is_finite());
+        assert!((0.0..=1.0).contains(score));
+    }
+    for score in prediction.map_scores.values() {
+        assert!(score.is_finite());
+        assert!((0.0..=1.0).contains(score));
+    }
+}

--- a/crates/orchestrator/tests/prefetch_planner.rs
+++ b/crates/orchestrator/tests/prefetch_planner.rs
@@ -88,6 +88,92 @@ fn planner_sorts_by_block_with_score_tiebreak() {
     assert_eq!(plan.maps, vec![map_b, map_c, map_a]);
 }
 
+/// Regression test for https://github.com/arunanshub/preload-rs/issues/233.
+///
+/// When some selected maps have no sort key (their backing file is gone, so
+/// `fs::metadata` fails) while others do, the old comparator mixed key-based
+/// and index-based tie-breaks per pair, violating transitivity and making
+/// `sort_by` panic with "user-provided comparison function does not correctly
+/// implement a total order".
+#[test]
+fn planner_sort_survives_maps_with_missing_files() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("data.bin");
+    std::fs::write(&path, vec![0u8; 1024 * 1024]).unwrap();
+
+    let mut config = Config::default();
+    config.model.memory = MemoryPolicy {
+        memtotal: 0,
+        memfree: 100,
+        memcached: 0,
+    };
+    config.system.sortstrategy = SortStrategy::Block;
+
+    let planner = GreedyPrefetchPlanner::new(&config);
+    let mut stores = Stores::default();
+
+    let mut prediction = Prediction::default();
+    let count = 64u64;
+    for i in 0..count {
+        // Every third map points at a file that does not exist (no sort key);
+        // the rest use decreasing offsets so key order opposes insertion order.
+        let map_id = if i % 3 == 0 {
+            stores.ensure_map(MapSegment::new(format!("/nonexistent/{i}"), 0, 1024, 0))
+        } else {
+            stores.ensure_map(MapSegment::new(&path, (count - i) * 4096, 1024, 0))
+        };
+        prediction.map_scores.insert(map_id, 1.0);
+    }
+
+    let mem = MemStat {
+        total: 0,
+        free: 1024 * 1024,
+        cached: 0,
+        pagein: 0,
+        pageout: 0,
+    };
+
+    let plan = planner.plan(&prediction, &stores, &mem);
+    assert_eq!(plan.maps.len(), count as usize);
+}
+
+/// NaN scores must not panic the planner's sorts either.
+#[test]
+fn planner_sort_survives_nan_scores() {
+    let mut config = Config::default();
+    config.model.memory = MemoryPolicy {
+        memtotal: 0,
+        memfree: 100,
+        memcached: 0,
+    };
+    config.system.sortstrategy = SortStrategy::Path;
+
+    let planner = GreedyPrefetchPlanner::new(&config);
+    let mut stores = Stores::default();
+
+    let mut prediction = Prediction::default();
+    for i in 0..64 {
+        let map_id = stores.ensure_map(MapSegment::new(format!("/map/{i}"), 0, 1024, 0));
+        let score = match i % 3 {
+            0 => f32::NAN,
+            1 => 1.0,
+            _ => 0.5,
+        };
+        prediction.map_scores.insert(map_id, score);
+    }
+
+    let mem = MemStat {
+        total: 0,
+        free: 1024 * 1024,
+        cached: 0,
+        pagein: 0,
+        pageout: 0,
+    };
+
+    let plan = planner.plan(&prediction, &stores, &mem);
+    assert_eq!(plan.maps.len(), 64);
+}
+
 #[test]
 fn planner_sorts_by_inode_with_score_tiebreak() {
     let dir = tempdir().unwrap();


### PR DESCRIPTION
closes #233 

## Summary
Fix panics in the prefetch planner's sorting logic that occurred when handling NaN scores or maps with missing files. The root cause was using `partial_cmp` with `unwrap_or` fallbacks, which violated transitivity requirements for sorting. Additionally, ensure the Markov predictor never produces NaN scores that could poison downstream sorting.

## Key Changes

**Planner sorting fixes:**
- Replace `partial_cmp().unwrap_or(Ordering::Equal)` with `total_cmp()` for score comparisons, which properly handles NaN values
- Refactor `sort_by_score_and_key` to use a strict total order: compare scores first, then sort keys (with `None` < `Some`), then insertion indices
- This ensures transitivity even when some maps lack sort keys (e.g., their backing files are gone)

**Predictor robustness:**
- Add `is_finite()` checks in `p_needed()` to reject NaN values from corrupt persisted Markov state
- Sanitize correlation coefficient calculation to return 0.0 instead of NaN when the result is non-finite
- Clamp final probability and return 0.0 if the result is NaN

**Test coverage:**
- Add regression test `planner_sort_survives_maps_with_missing_files` for the transitivity issue with 64 maps (every third has no sort key)
- Add `planner_sort_survives_nan_scores` test to verify NaN scores don't panic the planner
- Add `predictor_scores_stay_finite_with_nan_edge_data` test with property-based testing using full f32 range to ensure scores remain finite even with corrupt persisted state

**Minor cleanup:**
- Remove unused `std::cmp::Ordering` import
- Simplify `try_wait()` check idiom in CLI tests

https://claude.ai/code/session_01V11Fy8VK2w4W26aqaPvUVU